### PR TITLE
added CMAF outputGroup Compatibility

### DIFF
--- a/MediaConvert-WorkflowWatchFolderAndNotification/convert.py
+++ b/MediaConvert-WorkflowWatchFolderAndNotification/convert.py
@@ -145,6 +145,12 @@ def handler(event, context):
                     templateDestinationKey = urlparse(templateDestination).path
                     logger.info("templateDestinationKey == %s", templateDestinationKey)
                     outputGroup['OutputGroupSettings']['MsSmoothGroupSettings']['Destination'] = destinationS3+templateDestinationKey
+                    
+                elif outputGroup['OutputGroupSettings']['Type'] == 'CMAF_GROUP_SETTINGS':
+                    templateDestination = outputGroup['OutputGroupSettings']['CmafGroupSettings']['Destination']
+                    templateDestinationKey = urlparse(templateDestination).path
+                    logger.info("templateDestinationKey == %s", templateDestinationKey)
+                    outputGroup['OutputGroupSettings']['CmafGroupSettings']['Destination'] = destinationS3+templateDestinationKey
                 else:
                     logger.error("Exception: Unknown Output Group Type %s", outputGroup['OutputGroupSettings']['Type'])
                     statusCode = 500


### PR DESCRIPTION
MediaConvert now supports OutputGroupSettings=CMAF_GROUP_SETTINGS. This simple change allows you to use this template type. 
